### PR TITLE
added operation get_by_name for OrgVdcNetwork

### DIFF
--- a/lib/vcloud/core/org_vdc_network.rb
+++ b/lib/vcloud/core/org_vdc_network.rb
@@ -11,12 +11,12 @@ module Vcloud
         @id = id
       end
 
-      def self.get_by_name(name)
-        q = Query.new('orgVdcNetwork', :filter => "name==#{name}")
+      def self.get_by_name_and_vdc_name(name, vdc_name)
+        q = Query.new('orgVdcNetwork', :filter => "name==#{name};vdcName==#{vdc_name}")
         unless res = q.get_all_results
-          raise "Error finding orgVdcNetwork by name #{name}"
+          raise "Error finding orgVdcNetwork by name:#{name} and vdc_name:#{vdc_name}"
         end
-        raise "orgVdcNetwork #{name} not found" unless res.size == 1
+        raise "orgVdcNetwork with name:#{name} and vdc_name:#{vdc_name} not found" unless res.size == 1
         return self.new(res.first[:href].split('/').last)
       end
 


### PR DESCRIPTION
If you are wondering, where are tests for this. ;-), they are in
vcloud-tools. Currently most of the integration tests lie in vcloud-tools. I
have added a test around this in vcloud-tools repo. 

we need to discuss how do we want to write tests for vcloud-core 
- either it can be tested along with vcloud-tools. 
- or we maintain tests in both repos. this can be painful.

@annashipman : pls take a look.  
