### PR TITLE
Add target for integration tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,15 @@ RSpec::Core::RakeTask.new(:spec) do |task|
   # tests to accidentially run (and succeed against!) an actual
   # environment, if Fog connection is not stubbed correctly.
   ENV['FOG_CREDENTIAL'] = 'random_nonsense_owiejfoweijf'
+  ENV['COVERAGE'] = 'true'
   task.pattern = FileList['spec/vcloud/**/*_spec.rb']
 end
 
 task :default => [:spec]
+
+RSpec::Core::RakeTask.new('integration') do |t|
+  t.pattern = FileList['spec/integration/**/*_spec.rb']
+end
 
 require "gem_publisher"
 task :publish_gem do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,26 +1,29 @@
-require 'simplecov'
+if ENV['COVERAGE']
+  require 'simplecov'
 
-SimpleCov.profiles.define 'gem' do
-  add_filter '/spec/'
-  add_filter '/features/'
-  add_filter '/vendor/'
+  SimpleCov.profiles.define 'gem' do
+    add_filter '/spec/'
+    add_filter '/features/'
+    add_filter '/vendor/'
 
-  add_group 'Libraries', '/lib/'
+    add_group 'Libraries', '/lib/'
+  end
+
+  SimpleCov.start 'gem'
 end
-
-SimpleCov.start 'gem'
 
 require 'bundler/setup'
 require 'vcloud/core'
 require 'support/stub_fog_interface.rb'
 
-
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  # do not change the coverage percentage, instead add more unit tests to fix coverage failures.
-  if SimpleCov.result.covered_percent < 71
-    print "ERROR::BAD_COVERAGE\n"
-    print "Coverage is less than acceptable limit(71%). Please add more tests to improve the coverage"
-    exit(1)
+if ENV['COVERAGE']
+  SimpleCov.at_exit do
+    SimpleCov.result.format!
+    # do not change the coverage percentage, instead add more unit tests to fix coverage failures.
+    if SimpleCov.result.covered_percent < 71
+      print "ERROR::BAD_COVERAGE\n"
+      print "Coverage is less than acceptable limit(71%). Please add more tests to improve the coverage"
+      exit(1)
+    end
   end
 end


### PR DESCRIPTION
I've added a target so I can run the integration tests as I start to make changes to core.

I've used the same method/style as used in Walker to ensure that coverage only runs for the unit tests. 
