### PR TITLE
[#62223252] QueryRunner integration test

### DIFF
--- a/spec/integration/query/query_runner_spec.rb
+++ b/spec/integration/query/query_runner_spec.rb
@@ -143,7 +143,7 @@ module Vcloud
           end
 
           it "returns a record with a defined name element" do
-            expect(@results.first[:href]).not_to be_empty
+            expect(@results.first[:name]).not_to be_empty
           end
 
           it "returns a record with a defined vdcName element" do


### PR DESCRIPTION
This tests the QueryRunner#available_query_types and QueryRunner#run methods, in particular for the common needs that our dependent tooling requires.

For #run, the :filter and :fields options are tested for the vAppTemplate type, which covers a lot of the vcloud-query usage.

There are other #run options that should also be tested, in particular sortAsc and sortDesc, but these can be added in a separate PR.

This PR adds a decent - passing - set of integration tests that can be built upon.
