### PR TITLE
[#62626870] DO NOT MERGE Remove confusing vcloud-query 'record type' column

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ NB: examples assume FOG_CREDENTIAL or FOG_VCLOUD_TOKEN has been set accordingly.
     # Get general usage info
     vcloud-query --help
 
-    # Get a list of all queriable types (left column)
+    # Get a list of all queriable entity types
     vcloud-query
 
     # Get all VMs with VMware Tools less than 9282, that are not a vApp Template:

--- a/lib/vcloud/core/query.rb
+++ b/lib/vcloud/core/query.rb
@@ -32,30 +32,10 @@ module Vcloud
     end
 
     def output_available_query_types
-      available_query_types = @query_runner.available_query_types
-      available_queries = collate_formats_for_types(available_query_types)
-      print_query_types(available_queries)
-    end
-
-    def collate_formats_for_types(available_queries)
-      queries = Hash.new { |h, k| h[k]=[] }
-      available_queries.each do |type, format|
-        queries[type] << format
+      @query_runner.available_query_types.each do |type_record_pair|
+        (type, record_format) = type_record_pair
+        puts type if record_format == "records"
       end
-      queries
-    end
-
-    def print_query_types(queries)
-      type_width = longest_query_type(queries)
-
-      queries.keys.sort.each do |type|
-        puts "%-#{type_width}s %s" % [type, queries[type].sort.join(',')]
-      end
-    end
-
-    def longest_query_type(queries)
-      return 0 if queries.keys.empty?
-      queries.keys.max_by{|key| key.length}.length
     end
 
     def output_header(results)

--- a/spec/vcloud/core/query_spec.rb
+++ b/spec/vcloud/core/query_spec.rb
@@ -5,20 +5,22 @@ describe Vcloud::Query do
 
     context "#run called with no type set on construction" do
 
-      it "should get and reformat query types" do
+      it "should output all types that are available in 'records' format" do
         query_runner = double(Vcloud::QueryRunner)
         allow(query_runner).to receive(:available_query_types) {
           [
             ['alice', 'references'],
             ['alice', 'records'],
-            ['bob', 'records']
+            ['bob', 'records'],
+            ['charlie', 'references'],
           ]
         }
 
         @query = Vcloud::Query.new(nil, {}, query_runner)
 
-        @query.should_receive(:puts).with("alice records,references")
-        @query.should_receive(:puts).with("bob   records")
+        @query.should_receive(:puts).with("alice")
+        @query.should_receive(:puts).with("bob")
+        @query.should_not_receive(:puts).with("charlie")
 
         @query.run
       end


### PR DESCRIPTION
DO NOT MERGE YET: will be adding further commits that remove format handling for non-'record' query formats.

vcloud-query with no options would return a list of 'queriable
Entity types', along with a comma-separated list of 'record formats'
available for this particular entity.

We only ever use the 'records' format. The other types just add noise.

Simplify the output of the tool to just list entity types
available in 'records' format.
