### PR TITLE
Fixing ownership info in .gemspec

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -8,8 +8,8 @@ require 'vcloud/core/version'
 Gem::Specification.new do |s|
   s.name        = 'vcloud-core'
   s.version     = Vcloud::Core::VERSION
-  s.authors     = ['Anna Shipman']
-  s.email       = ['anna.shipman@digital.cabinet-office.gov.uk']
+  s.authors     = ['Government Digital Services']
+  s.email       = ['govuk-dev@digital.cabinet-office.gov.uk']
   s.summary     = 'Core tools for interacting with VMware vCloud Director'
   s.description = 'Core tools for interacting with VMware vCloud Director. Includes VCloud Query, a light wrapper round the vCloud Query API.'
   s.homepage    = 'http://github.com/alphagov/vcloud-core'


### PR DESCRIPTION
Following [this precedent](https://github.com/alphagov/vcloud-walker/commit/a7eedfb9b88c88b76f36ac27768c4d5ab47f2c90), the .gemspec should
attribute ownership to GDS and provide a group email,
so that the team can be contacted instead of individuals
(who may or may not be maintaining this gem in the future).

/cc @annashipman @danielabel @mikepea
