### PR TITLE
Unwrap non-indented line in #generate_preamble

### DIFF
--- a/lib/vcloud/core/vm.rb
+++ b/lib/vcloud/core/vm.rb
@@ -114,8 +114,7 @@ module Vcloud
 
       def generate_preamble(script_path, script_post_processor, vars)
         vapp_name = @vapp.name
-        script = ERB.new(File.read(File.expand_path(script_path)), nil, '>-')
-        .result(binding)
+        script = ERB.new(File.read(File.expand_path(script_path)), nil, '>-').result(binding)
         if script_post_processor
           script = Open3.capture2(File.expand_path(script_post_processor),
                                   stdin_data: script).first


### PR DESCRIPTION
The call to `#result` is a method of the preceeding line but the lack of
indentation doesn't make this apparent. So unwrap it back to the preceding
line. This makes the line longer but not unusually so for the rest of the
file.
