### PR TITLE
[#69995588] Actually bump version to 0.2.0

### DIFF
--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
In a7d371d49211be4c8e45c373f172bafa9e93e538 I omitted to bump the
version to 0.2.0 in `lib/vcloud/core/version.rb`.
