### PR TITLE
[#70499778] Add TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+language: ruby
+rvm:
+  - 1.9.3
+branches:
+  except:
+    - master
+notifications:
+  email: false


### PR DESCRIPTION
In preperation for enabling TravisCI to run lint and unit tests against our
pull requests. This:
- Uses the Ruby defaults such as `bundle install` and `bundle exec rake`.
- Only tests 1.9.3 at the moment, which I think is what we're targetting?
  But we might want to extend it to 2.x in the future.
- Doesn't test against master because that is handled by our in-house CI
  system which also runs integration tests.
- Disables email notifications because we already get a lot of email and the
  PR status hook on GitHub should be good enough.

---

I'll start by enabling it end-to-end on this project. Then work through the others.
