### PR TITLE
[#70437918] Simplify EdgeGatewayInterface defenses

### DIFF
--- a/lib/vcloud/core/edge_gateway_interface.rb
+++ b/lib/vcloud/core/edge_gateway_interface.rb
@@ -5,16 +5,16 @@ module Vcloud
       attr_accessor :name, :network_href, :network_name
 
       def initialize(gateway_interface_hash)
-        raise "Argument error: nil not allowed" if gateway_interface_hash.nil?
-        raise "Argument error: must have a :Name" unless gateway_interface_hash[:Name]
-        network_section = gateway_interface_hash[:Network]
-        raise "Argument error: must have a :Network section" unless network_section
-        raise "Argument error: must have a :Network[:href]" unless network_section[:href]
-        raise "Argument error: must have a :Network[:name]" unless network_section[:name]
+        if gateway_interface_hash.nil?
+          raise "EdgeGatewayInterface: gateway_interface_hash cannot be nil" 
+        end
+        unless gateway_interface_hash[:Name] && gateway_interface_hash[:Network]
+          raise "EdgeGatewayInterface: bad input: #{gateway_interface_hash}"
+        end
         @vcloud_gateway_interface = gateway_interface_hash
         @name = gateway_interface_hash[:Name]
-        @network_href = network_section[:href]
-        @network_name = network_section[:name]
+        @network_href = gateway_interface_hash[:Network][:href]
+        @network_name = gateway_interface_hash[:Network][:name]
       end
 
       def network_id

--- a/spec/vcloud/core/edge_gateway_interface_spec.rb
+++ b/spec/vcloud/core/edge_gateway_interface_spec.rb
@@ -40,31 +40,18 @@ module Vcloud
         end
 
         it "should raise an error if passed a nil value" do
-          expect { EdgeGatewayInterface.new(nil) }.to raise_error("Argument error: nil not allowed")
+          expect { EdgeGatewayInterface.new(nil) }.
+            to raise_error(StandardError, /^EdgeGatewayInterface:/)
         end
 
         it "should raise an error if a :Name is not passed" do
-          expect { EdgeGatewayInterface.new({}) }.to raise_error("Argument error: must have a :Name")
+          expect { EdgeGatewayInterface.new({}) }.
+            to raise_error(StandardError, /^EdgeGatewayInterface:/)
         end
 
         it "should raise an error if a :Network is not passed" do
-          expect { EdgeGatewayInterface.new({Name: 'test-interface'}) }.to raise_error("Argument error: must have a :Network section")
-        end
-
-        it "should raise an error if a :Network :href is not passed" do
-          bad_input = {
-            Name: 'test-interface',
-            Network: { name: "test-network" }
-          }
-          expect { EdgeGatewayInterface.new(bad_input) }.to raise_error("Argument error: must have a :Network[:href]")
-        end
-
-        it "should raise an error if a :Network :name is not passed" do
-          bad_input = {
-            Name: 'test-interface',
-            Network: { href: "http://example.com/1234" }
-          }
-          expect { EdgeGatewayInterface.new(bad_input) }.to raise_error("Argument error: must have a :Network[:name]")
+          expect { EdgeGatewayInterface.new({Name: 'test-interface'}) }.
+            to raise_error(StandardError, /^EdgeGatewayInterface:/)
         end
 
       end


### PR DESCRIPTION
EdgeGatewayInterface is an internal-use class, we don't need
to be excessive with the input checking.

Simplified the input checking to ensure that we don't unnecessarily
create NilClass exceptions.

Tests adjusted tests accordingly.
