### PR TITLE
[#70437918] Add rubocop to default Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rspec/core/rake_task'
 require 'cucumber/rake/task'
 
-task :default => [:spec, :features]
+task :default => [:rubocop, :spec, :features]
 
 RSpec::Core::RakeTask.new(:spec) do |task|
   # Set a bogus Fog credential, otherwise it's possible for the unit


### PR DESCRIPTION
All rubocop issues fixed in separate PRs, this enables it in our CI by adding to the default Rake task.
