### PR TITLE
Fail integration tests fast

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,3 +28,7 @@ if ENV['COVERAGE']
     end
   end
 end
+
+RSpec.configure do |c|
+    c.fail_fast = true
+end


### PR DESCRIPTION
Cause integration tests to fail on the first error encountered.

The vCloud Tools don't handle ^C well so it's not easy to stop tests
once they have started. Given that integration tests can be slow to
complete, I think it's useful for them to fail on the first error.

More about this option:
https://www.relishapp.com/rspec/rspec-core/v/2-14/docs/configuration/fail-fast

---

If this is merged, I'll raise a story to add this to the other tools.
