### PR TITLE
Doc typo, instance method instead of class method

### DIFF
--- a/lib/vcloud/core/config_validator.rb
+++ b/lib/vcloud/core/config_validator.rb
@@ -17,7 +17,7 @@ require 'ipaddr'
 #
 #   These methods then recursively instantiate this class by calling
 #   ConfigValidator::validate again (ConfigValidator#validate_hash calls this
-#   indirectly via the ConfigValidator::check_hash_parameter method).
+#   indirectly via the ConfigValidator#check_hash_parameter method).
 
 module Vcloud
   module Core


### PR DESCRIPTION
The `check_hash_parameter` method is an instance method like `validate_hash`
and not a class method like `validate`, so it should have a `#` notation
instead of `::`.

/cc @mattbostock, PRing this myself because I didn't want to hold the other PR up any longer.
