### PR TITLE
Optionally cause Rspec tests to fail fast

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,3 +28,9 @@ if ENV['COVERAGE']
     end
   end
 end
+
+RSpec.configure do |c|
+  if ENV['VCLOUD_TOOLS_RSPEC_FAIL_FAST']
+    c.fail_fast = true
+  end
+end


### PR DESCRIPTION
Optionally cause Rspec tests to fail on the first error encountered.

The vCloud Tools don't handle ^C well on my machine so it's not easy to
stop tests once they have started. Given that integration tests can be
slow to complete, I think it's useful for them to fail on the first
error.

Use the `VCLOUD_TOOLS_RSPEC_FAIL_FAST` environment variable to determine
whether Rspec should fail fast or not. The default is leave `fail_fast`
disabled, as was this case before this commit.

More about `fail_fast`:
https://www.relishapp.com/rspec/rspec-core/v/2-14/docs/configuration/fail-fast

---

Note that `ENV['VCLOUD_TOOLS_RSPEC_FAIL_FAST']` will evaulate to true if `VCLOUD_TOOLS_RSPEC_FAIL_FAST` is set to any value other than a boolean `false` or `nil` value. So `VCLOUD_TOOLS_RSPEC_FAIL_FAST=0` will evaluate to `true`. I can't find an _elegant_ way to handle this in Ruby; does this matter?
