### PR TITLE
Remove vcloud-tools-testing-config after use

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -9,6 +9,7 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}"
 # Obtain the integration test parameters
 git clone git@github.gds:gds/vcloud-tools-testing-config.git
 mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 bundle exec rake
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration

--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -5,5 +5,6 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}"
 # Obtain the integration test parameters
 git clone git@github.gds:gds/vcloud-tools-testing-config.git
 mv vcloud-tools-testing-config/vcloud_tools_testing_config.yaml spec/integration/
+rm -rf vcloud-tools-testing-config
 
 RUBYOPT="-r ./tools/fog_credentials" bundle exec rake integration


### PR DESCRIPTION
CI is failing intermittently because the workspace isn't deleted
before/after each build and the previous clone of the config repo already
exists.

```
fatal: destination path 'vcloud-tools-testing-config' already exists and is not an empty directory.
Build step 'Execute shell' marked build as failure
```

Prevent this from happening by deleting the repo/dir after we've moved the
one file out of it. We could also amend the `git clean` to `-ffdx`, but I
think it's better to be explicit here.
