### PR TITLE
Remove vcloud-tools-testing-config BEFORE tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,9 +1,7 @@
 #!/bin/bash -x
 set -e
 
-rm -f Gemfile.lock
-git clean -fdx
-
+git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 # Obtain the integration test parameters

--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 set -e
+
+git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 
 # Obtain the integration test parameters


### PR DESCRIPTION
Tell `git clean` to remove untracked git repositories before fetching
vcloud-tools-testing-config. Although 6232186 was a good thing to do, it
didn't solve the immediate problem of the directory existing in our
workspaces right now, only after a successful clone.

I've removed the `rm -f Gemfile.lock` because it's covered by `git clean`
(as the file isn't tracked and the `-x` says to disregard `.gitignore`).
