### PR TITLE
[#72271312] Enable TravisCI for our master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,5 @@
 language: ruby
 rvm:
   - 1.9.3
-branches:
-  except:
-    - master
 notifications:
   email: false


### PR DESCRIPTION
Pull requests from forks aren't being tested by Travis. We have a theory
that this is because we've disabled builds for the master branch and there's
a hint in the docs that pull requests don't work the same as normal branch
builds: http://docs.travis-ci.com/user/pull-requests/#My-Pull-Request-isn't-being-build

> We rely on the merge commit that GitHub transparently creates between the
> changes in the source branch and the upstream branch the pull request is
> sent against.

The reason we originally disabled this branch is because it's also tested by
our in-house CI. However in reality it's not such a big deal for it to be
tested twice. At worst we tie up a Travis worker for a little longer than we
need.
