### PR TITLE
Version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.5.0 (UNRELEASED)
+## 0.5.0 (2014-05-30)
 
 Features:
 
   - `vcloud-query --version` now only returns the version string and no
     usage information.
+  - Support 'pool' mode for VM IP address allocation.
 
 ## 0.4.0 (2014-05-23)
 

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end


### PR DESCRIPTION
Bump the version to 0.5.0 and update the CHANGELOG to reflect the
changes introduced in e22226ad19ca09fd017f3c03121dad3a7446db66.

Releasing this now so that the pull request alphagov/vcloud-launcher#35
can be merged as it depends on these changes.
