### PR TITLE
Fix Rubydoc comments for Vcloud::Core::ConfigValidator

### DIFF
--- a/lib/vcloud/core/config_validator.rb
+++ b/lib/vcloud/core/config_validator.rb
@@ -1,26 +1,26 @@
 require 'ipaddr'
 
-##
-# self::validate is entry point; this class method is called to
-# instantiate ConfigValidator. For example:
-#
-# Core::ConfigValidator.validate(key, data, schema)
-#
-# = Recursion in this class
-#
-# Note that this class will recursively call itself in order to validate deep
-# hash and array structures.
-#
-# The +data+ variable is usually either an array or hash and so will pass
-# through the ConfigValidator#validate_array and
-# ConfigValidator#validate_hash methods respectively.
-#
-# These methods then recursively instantiate this class by calling
-# ConfigValidator::validate again (ConfigValidator#validate_hash calls this
-# indirectly via the ConfigValidator#check_hash_parameter method).
-#
 module Vcloud
   module Core
+    ##
+    # self::validate is entry point; this class method is called to
+    # instantiate ConfigValidator. For example:
+    #
+    # Core::ConfigValidator.validate(key, data, schema)
+    #
+    # = Recursion in this class
+    #
+    # Note that this class will recursively call itself in order to validate deep
+    # hash and array structures.
+    #
+    # The +data+ variable is usually either an array or hash and so will pass
+    # through the ConfigValidator#validate_array and
+    # ConfigValidator#validate_hash methods respectively.
+    #
+    # These methods then recursively instantiate this class by calling
+    # ConfigValidator::validate again (ConfigValidator#validate_hash calls this
+    # indirectly via the ConfigValidator#check_hash_parameter method).
+    #
     class ConfigValidator
 
       attr_reader :key, :data, :schema, :type, :errors, :warnings


### PR DESCRIPTION
Move the Rubydoc comments intended for the Vcloud::Core::ConfigValidator class.

[Yard](http://yardoc.org/) was associating these comments to the `Vcloud` module; move them so that they appear under the `ConfigValidator` class. See [Rubydoc.info](http://rubydoc.info/gems/vcloud-core/Vcloud) for an example.

Also, fix the formatting for these comments.
