### PR TITLE
Create fixtures for EdgeGateway integration tests

### DIFF
--- a/spec/support/integration_helper.rb
+++ b/spec/support/integration_helper.rb
@@ -32,6 +32,75 @@ module IntegrationHelper
     end
   end
 
+  def self.ensure_networks_correct(test_params)
+    vcloud = ::Fog::Compute::VcloudDirector.new
+    org = vcloud.organizations.get_by_name(vcloud.org_name)
+    interfaces = org.networks.all(false)
+
+    network_config = {
+      :network_1 => {
+        :is_shared    => 'true',
+        :name         => test_params["network_1"],
+        :vdc_name     => test_params["vdc_1_name"],
+        :fence_mode   => 'natRouted',
+        :netmask      => '255.255.255.0',
+        :gateway      => '192.168.1.1',
+        :edge_gateway => test_params["edge_gateway"],
+        :ip_ranges    => [
+          {
+            :start_address  => "192.168.1.2",
+            :end_address    => "192.168.1.254"
+          }
+        ],
+      },
+      :network_2 => {
+        :is_shared    => 'true',
+        :name         => test_params["network_2"],
+        :vdc_name     => test_params["vdc_2_name"],
+        :fence_mode   => 'isolated',
+        :netmask      => '255.255.0.0',
+        :gateway      => '10.0.0.1',
+        :edge_gateway => test_params["edge_gateway"],
+        :ip_ranges    => [
+          {
+            :start_address  => "10.0.0.2",
+            :end_address    => "10.0.255.254"
+          }
+        ],
+      },
+    }
+
+    %w(network_1 network_2).each do |test_network|
+      found_network = interfaces.detect { |i| i.name == test_params[test_network] }
+      expected_config = network_config[:"#{test_network}"]
+
+      if found_network
+        test_params[test_network + "_id"] = found_network.id
+      else
+        new_network = Vcloud::Core::OrgVdcNetwork.provision(expected_config)
+        test_params[test_network + "_id"] = new_network.id
+        next
+      end
+
+      expected_ip_range = expected_config[:ip_ranges][0]
+
+      fence_mode = (found_network.fence_mode == expected_config[:fence_mode])
+      ip_range = found_network.ip_ranges.detect do |r|
+        r[:start_address] == expected_ip_range[:start_address]
+      end
+
+      ip_range   = (ip_range && ip_range[:end_address] == expected_ip_range[:end_address])
+      gateway    = (found_network.gateway    == expected_config[:gateway])
+      netmask    = (found_network.netmask    == expected_config[:netmask])
+      is_shared  = (found_network.is_shared  == expected_config[:is_shared])
+
+      unless fence_mode && gateway && netmask && ip_range && is_shared
+        raise "Network '#{test_params[test_network]}' already exists but is not configured as expected.
+          You should delete this network before re-running the tests; it will be re-created by the tests."
+      end
+    end
+  end
+
   def self.reset_edge_gateway(edge_gateway)
     configuration = {
         :FirewallService =>


### PR DESCRIPTION
Add a new helper function for the Vcloud::Core::EdgeGateway integration
tests, IntegrationHelper::ensure_networks_correct, that checks if the
networks required for the integration tests already exist in the test
organisation and if not, create them.
## These fixtures are re-used

Notice that we don't tear down the networks once tests have finished.
There are two reasons for this; firstly because deleting and creating
networks can be expensive operations and secondly because many other
tests rely on these networks and have not yet been converted to create
these fixtures as required. I'm no longer convinced that setting up and
tearing down the networks before and after each test run is so
expensive, so it's worth reexamining this once all of the other tests
are able to setup their fixtures as required (see story 67916012).

If a network with the same name as the test networks already exists, we
check its configuration and raise an error if it is incorrectly
configured for our tests. Raise an error rather than deleting these
networks as it's less aggressive and an existing network with a
different configuration may indicate an underlying issue, i.e. perhaps
the tests are running against the wrong organisation.
## Impact on other integration tests

As these network fixtures are currently undocumented, these tests impact
the other integration tests both in this gem and in the other vCloud
Tools gems. The steps to make these work are:
1. ~~Delete the existing networks in the CI environment via the vCloud
   Director GUI.~~ [Already done]
2. ~~Run just the Core::EdgeGateway integration tests using `bundle exec
   rspec spec/integration/core/edge_gateway_spec.rb`.~~ [Already done]
3. ~~Ensure that `network_1_ip` and `network_2_ip` are set to
   `192.168.1.2` and `10.0.0.2` respectively.~~ [Already done]
4. Once the Core::EdgeGateway tests have run, set the '_id' test
   parameters to the UUID used by the new networks that have just been
   created. You might need to use vcloud-walk to do this. This is
   necessary so that integration tests not using this helper method
   continue to function.
5. All tests should now run successfully.
## IsEnabled

Note that we don't check the 'IsEnabled' property of the network
adapters as it's not exposed by the call to
Fog::Compute::VcloudDirector::Collection#all. We could make an extra
call to the API separately but in reality a disabled network is an edge
case and I don't think it's worth the extra API call.
## Retrieving the list of networks

We use Fog::Compute::VcloudDirector::Collection#all to retrieve the list
of networks in the organisation instead of
Vcloud::Core::EdgeGateway#interfaces as that method does not return
_isolated_ networks, which appear not to associate to a specific Edge
Gateway. Interestingly, the EdgeGateway#interfaces method _does_ return
the 'IsEnabled' property for network interfaces (see comments above).
## Test parameters that we ignore

We define an array of test parameters (populated with values from the
vCloud Tools Tester gem) so that we can modify the parameters later.
This is necessary so that we can set the network UUID (`network_1_id`
and `network_2_id` specifically) if the networks have been created by
the IntegrationHelper::ensure_networks_correct method.

The '_id' parameters are effectively now ignored by the
Core::EdgeGateway integration tests as we set these by querying the
environment.

Once other gems have been updated in the same vein, we should remove
these as test parameters so that they are no longer read from the
configuration file consumed by vCloud Tools Tester.

We may need more flexibility in the vCloud Tools Tester gem either so
that test parameters can be modified, or so that vCloud Tools Tester
assumes the responsibility of setting up test fixtures.

Thanks for reading this far ;-)
