### PR TITLE
Document validation for nil value

### DIFF
--- a/spec/vcloud/core/config_validator_spec.rb
+++ b/spec/vcloud/core/config_validator_spec.rb
@@ -73,6 +73,13 @@ module Vcloud
           expect(v.valid?).to be_true
         end
 
+        it "should return error for nil value with allowed_empty: true)" do
+          data = nil
+          schema = { type: 'string', allowed_empty: true }
+          v = ConfigValidator.validate(:base, data, schema)
+          expect(v.errors).to eq([ 'base:  is not a string'] )
+        end
+
         it "should validate ok with a :matcher regex specified" do
           data = "name-1234"
           schema = { type: 'string', matcher: /^name-\d+$/ }


### PR DESCRIPTION
Add a test to document ConfigValidator's behaviour when passed a nil
value against a schema expecting a string when `allowed_empty` is set to
`true`.

This is useful to understand due to the way that Ruby's YAML library
parser returns `nil` if nothing is specified after the member's key
name:

``` ruby
> YAML::load('base:')
=> {"base"=>nil}

> YAML::load('base: ')
=> {"base"=>nil}

> YAML::load('base: ""')
=> {"base"=>""}
```
