### PR TITLE
Add support for FOG_MOCK in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,11 +32,9 @@ RSpec.configure do |config|
   end
 end
 
-# Set FOG_MOCK=true to enable Fog Mock mode.
-# NB: Your test data will need to reflect the 'initial data structure' in 
-#     https://github.com/fog/fog/blob/master/lib/fog/vcloud_director/compute.rb#L483
-# 
-# Use FOG_CREDENTIAL=fog_mock in vcloud_tools_tester
+# To enable Fog Mock mode use FOG_CREDENTIAL=fog_mock and FOG_MOCK=true
+# If you do not have configuration for fog_mock in your vcloud_tools_testing_config.yaml,
+# the test data is defined here: https://github.com/fog/fog/blob/master/lib/fog/vcloud_director/compute.rb#L483-L733
 # 
 if ENV['FOG_MOCK']
   Fog.mock!


### PR DESCRIPTION
This is the common pattern for enabling Fog Mock mode (via `Fog.mock!`) in tests.
