### PR TITLE
[#73379346] Update required version to 1.9.3

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '>= 1.22.0'
   s.add_runtime_dependency 'mustache'


### PR DESCRIPTION
As per https://github.com/gds-operations/vcloud-tools/pull/194/.
