### PR TITLE
[#72866380] Specify the required user-defined test params

### DIFF
--- a/spec/integration/core/edge_gateway_spec.rb
+++ b/spec/integration/core/edge_gateway_spec.rb
@@ -6,7 +6,15 @@ module Vcloud
 
       before(:all) do
         config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-        @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+        required_user_params = [
+          "edge_gateway",
+          "edge_gateway_id",
+          "network_1",
+          "network_1_id",
+          "provider_network_id",
+        ]
+
+        @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
       end
 
       let(:edge_gateway) { EdgeGateway.get_by_name(@test_params.edge_gateway) }

--- a/spec/integration/core/query_runner_spec.rb
+++ b/spec/integration/core/query_runner_spec.rb
@@ -6,7 +6,13 @@ module Vcloud
 
       before(:all) do
         config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-        test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+        required_user_params = [
+          "catalog",
+          "vapp_template",
+          "vdc_1_name",
+        ]
+
+        test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
         @vapp_template_name = test_params.vapp_template
         @vapp_template_catalog_name = test_params.catalog
         @vdc_name = test_params.vdc_1_name

--- a/spec/integration/core/vapp_spec.rb
+++ b/spec/integration/core/vapp_spec.rb
@@ -6,7 +6,15 @@ describe Vcloud::Core::Vapp do
 
   before(:all) do
     config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+    required_user_params = [
+      "catalog",
+      "network_1",
+      "network_2",
+      "vapp_template",
+      "vdc_1_name",
+    ]
+
+    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
     @vapp_name_prefix = "vcloud-core-vapp-tests"
     quantity_of_test_case_vapps = 1
     @network_names = [ @test_params.network_1, @test_params.network_2 ]

--- a/spec/integration/core/vdc_spec.rb
+++ b/spec/integration/core/vdc_spec.rb
@@ -6,7 +6,9 @@ describe Vcloud::Core::Vdc do
 
   before(:all) do
     config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+    required_user_params = %w{ vdc_1_name }
+
+    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
   end
 
   describe ".get_by_name" do

--- a/spec/integration/core/vm_spec.rb
+++ b/spec/integration/core/vm_spec.rb
@@ -4,7 +4,19 @@ describe Vcloud::Core::Vm do
 
   before(:all) do
     config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+    required_user_params = [
+      "catalog",
+      "default_storage_profile_name",
+      "network_1",
+      "network_1_ip",
+      "network_2",
+      "network_2_ip",
+      "storage_profile",
+      "vapp_template",
+      "vdc_1_name",
+    ]
+
+    @test_params = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
     @network_names = [ @test_params.network_1, @test_params.network_2 ]
     @network_ips = {
       @test_params.network_1 => @test_params.network_1_ip,


### PR DESCRIPTION
By specifying the user-defined test parameters we require for each test,
vCloud Tools Tester will fail fast if these parameters are not defined.
