### PR TITLE
Relax dev dep on vcloud-tools-tester

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '0.1.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 0.1.0'
 end


### PR DESCRIPTION
In gds-operations/vcloud-tools-tester#18 we bumped `vcloud-tools-tester`
to version `0.1.2` when resolving a cyclical runtime dependency on
vcloud-core. We now need to relax the development dependency here to
allow vcloud-core to build, at which point we can publish new versions
of the other gems.
