### PR TITLE
Fix LoginCli test failures on Jenkins

### DIFF
--- a/spec/vcloud/core/login_cli_spec.rb
+++ b/spec/vcloud/core/login_cli_spec.rb
@@ -128,14 +128,18 @@ describe Vcloud::Core::LoginCli do
       # We have to pass a string here to prevent highline blowing up. This
       # appears to be related to swapping out $stdin for StringIO and can't
       # be reproduced by normal CLI use.
-      let(:stdin) { 'some string' }
+      let(:pass) { 'some string' }
+      let(:stdin) { pass }
+      let(:exception_string) { 'something went horribly wrong' }
 
       it "should print error without backtrace and exit abnormally" do
         expect(Vcloud::Fog::Login).to receive(:token_export).
-          and_raise('something went horribly wrong')
-        expect(subject.stderr).to match(
-          /(vCloud password: |Reading password from pipe\.\.)\nsomething went horribly wrong/
-        )
+          and_raise(exception_string)
+        if STDIN.tty?
+          expect(subject.stderr).to eq("vCloud password: #{'*' * pass.size}\n#{exception_string}")
+        else
+          expect(subject.stderr).to eq("Reading password from pipe..\n#{exception_string}")
+        end
         expect(subject.exitstatus).to eq(1)
       end
     end


### PR DESCRIPTION
#### Pass STDIN string to LoginCli exception test

This test appears to require a non-empty string when run from a
non-interactive terminal such as Jenkins. It can be reproduced by piping
input to rspec:

```
➜  vcloud-core git:(vcloud_login_cli_test_failure) ✗ echo | b rspec spec/vcloud/core/login_cli_spec.rb:133
Run options: include {:locations=>{"./spec/vcloud/core/login_cli_spec.rb"=>[133]}}
F

Failures:

  1) Vcloud::Core::LoginCli error handling when underlying code raises an exception should print error without backtrace and exit abnormally
     Failure/Error: expect(subject.stderr).to eq("vCloud password: \nsomething went horribly wrong")

       expected: "vCloud password: \nsomething went horribly wrong"
            got: "Reading password from pipe..\nundefined method `strip' for nil:NilClass"
```

I can't reproduce this by calling `vcloud-login` without rspec so I'm think
it's something to do with how we're instrumenting $stdin with StringIO. As
such I don't feel SO bad about this fix, even if it requires a long comment.

I've also removed with `.with()` expectation because we don't really care
about that in this test. We have others to ensure that the class gets the
right args.

NB: I did try highline's `whitespace = nil` option but it then blows up when
calling `nil.length`.
#### Allow LoginCli test to run from non-interactive

This test failed on Jenkins because `STDIN.tty?` returns false and we expect
the password to be piped in. So allow it to match either message.

---

Fixes errors here: https://ci-new.alphagov.co.uk/view/vCloud%20Tools/job/vcloud-core/96/console
