### PR TITLE
[#68989754] Make call match the name of the script

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
 set -e
 
-./jenkins_test.sh
+./jenkins_tests.sh
 bundle exec rake publish_gem

--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -2,4 +2,4 @@
 set -e
 
 # FIXME: Change the Carrenza job to use the following script directly.
-./jenkins_test.sh
+./jenkins_tests.sh


### PR DESCRIPTION
CI is failing because the script being called doesn't exist
