### PR TITLE
Remove FIXME added in #100

### DIFF
--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -7,11 +7,6 @@ git clean -ffdx
 # Ubuntu 12.04 has a bug we hit in Psych when loading YAML files.
 export RBENV_VERSION="1.9.3"
 
-#FIXME: This can be removed once the tests have cycled through all 4 CI machines (a week or two after #100 is merged)
-# As we weren't using rbenv before, we've ended up with binstubs referencing ruby1.9.1
-# This line detects them, deletes the cache if it finds any and forces a new build with --shebang ruby
-grep -Rq ruby1\.9\.1 ${HOME}/bundles/${JOB_NAME}/ruby/1.9.1/bin && echo "Deleting cached gems with ruby1.9.1 shebangs" && rm -rf ${HOME}/bundles/${JOB_NAME}/*
-# END FIXME
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --shebang="/usr/bin/env ruby"
 
 # Obtain the integration test parameters


### PR DESCRIPTION
I manually deleted the gem cache from all the CI machines after
verifying that the fix to rebuild the binstubs without ruby1.9.1 in them
worked. That means this FIXME is FIXED, so yeah. Well done me.
