### PR TITLE
[#72170126] Remove redundant jenkins_integration_tests.sh

### DIFF
--- a/jenkins_integration_tests.sh
+++ b/jenkins_integration_tests.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-# FIXME: Change the Carrenza job to use the following script directly.
-./jenkins_tests.sh


### PR DESCRIPTION
CI jobs for Carrenza have been changed to use `jenkins_tests.sh` directly:

https://github.gds/gds/jenkins-config-ci-new/compare/d8cfee63e9b8caea85e4a0fd866168a4c45fc216...f2ee83a439628830a37d8b542d5333596f73875b

Excuse the other changes in that diff. It seems that Jenkins doesn't persist
changes with "apply" so they include other changes since the jobs were last
"saved".
