### PR TITLE
[#76118720] Replace ENV.clone mock with empty hash

### DIFF
--- a/spec/integration/fog/login_spec.rb
+++ b/spec/integration/fog/login_spec.rb
@@ -24,7 +24,7 @@ describe Vcloud::Fog::Login do
           Fog::Errors::LoadError,
           /^Missing Credentials\n/
         )
-        expect { subject.token(@real_password) }.to raise_error(
+        expect { subject.token('supersekret') }.to raise_error(
           ArgumentError,
           /^Missing required arguments: vcloud_director_.*$/
         )


### PR DESCRIPTION
ENV.clone only performs a shallow-copy of the ENV object. Which means that
`mock_env.clear` wipes the real ENV object and affects other tests that run
after this.

We didn't notice it because this is currently the last test picked up by
`rake integration`, but when we attempted to move it in #108 it made all of
the other tests fail. This can also be tested by placing the following at
the end of this spec file:

```
describe 'after' do
  it { expect(ENV.to_hash).to_not eq({}) }
end
```

Replace it with an empty hash. While this isn't truly the same as the ENV
object because it doesn't implement all of the same methods it should
suffice for the things that Fog needs.

I don't think the `login_manual.rb` test is affected because it uses
`ENV.to_hash` instead. However, since this test it only run manually, I
don't think it matters that much right now.
