### PR TITLE
Ban plaintext passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.11.0 (XXXX-XX-XX)
+
+Changes:
+
+  - As deprecated in 0.7.0, it is now impossible to specify a plaintext
+    password in a FOG_RC file. Please use tokens vcloud-login instead as
+    per the documentation: http://gds-operations.github.io/vcloud-tools/usage/
+
 ## 0.10.0 (2014-08-11)
 
 API changes:

--- a/lib/vcloud/core/fog.rb
+++ b/lib/vcloud/core/fog.rb
@@ -11,15 +11,7 @@ module Vcloud
       FOG_CREDS_PASS_NAME = :vcloud_director_password
 
       def self.check_credentials
-        pass = fog_credentials_pass
-        unless pass.nil? or pass.empty?
-          warn <<EOF
-[WARNING] Storing :vcloud_director_password in your plaintext FOG_RC file is
-          insecure. Future releases of vcloud-core (and tools that depend on
-          it) will prevent you from doing this. Please use vcloud-login to
-          get a session token instead.
-EOF
-        end
+        check_plaintext_pass
       end
 
       def self.fog_credentials_pass
@@ -33,6 +25,16 @@ EOF
 
         pass
       end
+
+      private
+
+      def self.check_plaintext_pass
+        pass = fog_credentials_pass
+        unless pass.nil? or pass.empty?
+          raise "Found plaintext #{Vcloud::Core::Fog::FOG_CREDS_PASS_NAME} entry. Please set it to an empty string as storing passwords in plaintext is insecure. See http://gds-operations.github.io/vcloud-tools/usage/ for further information."
+        end
+      end
+
     end
   end
 end

--- a/lib/vcloud/core/fog/login.rb
+++ b/lib/vcloud/core/fog/login.rb
@@ -6,7 +6,7 @@ module Vcloud
       module Login
         class << self
           def token(pass)
-            check_plaintext_pass
+            Vcloud::Core::Fog.check_credentials
             token = get_token(pass)
 
             return token
@@ -17,13 +17,6 @@ module Vcloud
           end
 
           private
-
-          def check_plaintext_pass
-            pass = Vcloud::Core::Fog::fog_credentials_pass
-            unless pass.nil? || pass.empty?
-              raise "Found plaintext #{Vcloud::Core::Fog::FOG_CREDS_PASS_NAME} entry. Please set it to an empty string"
-            end
-          end
 
           def get_token(pass)
             ENV.delete(Vcloud::Core::Fog::TOKEN_ENV_VAR_NAME)

--- a/spec/vcloud/core/fog/login_spec.rb
+++ b/spec/vcloud/core/fog/login_spec.rb
@@ -4,7 +4,6 @@ require 'stringio'
 describe Vcloud::Core::Fog::Login do
   describe "#token" do
     it "should return the output from get_token" do
-      expect(subject).to receive(:check_plaintext_pass)
       expect(subject).to receive(:get_token).and_return('mekmitasdigoat')
       expect(subject.token('supersekret')).to eq("mekmitasdigoat")
     end
@@ -40,7 +39,7 @@ describe Vcloud::Core::Fog::Login do
         expect(subject).to_not receive(:get_token)
         expect { subject.token('supersekret') }.to raise_error(
           RuntimeError,
-          "Found plaintext vcloud_director_password entry. Please set it to an empty string"
+          "Found plaintext vcloud_director_password entry. Please set it to an empty string as storing passwords in plaintext is insecure. See http://gds-operations.github.io/vcloud-tools/usage/ for further information."
         )
       end
     end


### PR DESCRIPTION
In version 0.7.0 we deprecated the use of plaintext passwords in FOG_RC
in a conscious move to promote that as bad practise. Interaction with
vcloud-tools should now be done by supplying a token, which can be
gained using `vcloud-login` (which will accept a password on STDIN).

This involved:
- Moving check_plaintext_pass into Vcloud::Core::Fog
- Calling check_plaintext_pass from check_credentials
- replacing call to check_plaintext_pass from Vcloud::Core::Fog::Login
  with call to Vcloud::Core::Fog.check_credentials
- Rescuing call to Vcloud::Core::Fog.check_credentials in
  `vcloud/core/fog.rb` to provide a nice error message to the user

Happy to be guided on better ways to do this - it's my first solo foray
into vcloud-tools.

Rubocop and Specs pass. Not much changed in the test apart from the
expected error message, which I have lengthened slighly to describe the
reason behind the error as well as what it means.
