### PR TITLE
[#78700334] Upgrade Fog dependency to version 1.24.0

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'fog', '>= 1.23.0'
+  s.add_runtime_dependency 'fog', '>= 1.24.0'
   s.add_runtime_dependency 'mustache'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Upgrade our dependency on Fog to versions 1.24.0 or above so as to
include the changes in this PR, which were released in 1.24.0:
- [Error if FOG_CREDENTIAL doesn't match
  session](https://github.com/fog/fog/pull/3169)
