### PR TITLE
Add IndependentDisk#destroy to delete a disk

### DIFF
--- a/lib/vcloud/core/independent_disk.rb
+++ b/lib/vcloud/core/independent_disk.rb
@@ -105,6 +105,13 @@ module Vcloud
         end
       end
 
+      # Delete the IndependentDisk entity referred to by this object.
+      #
+      # @return [Boolean] Returns true if disk was deleted. Raises an exception otherwise.
+      def destroy
+        Vcloud::Core::Fog::ServiceInterface.new.delete_disk(id)
+      end
+
       # Convert an integer and units suffix (e.g. 10mb) into an integer of bytes
       # Allowed suffixes are: mb, gb, mib, gib
       #

--- a/spec/integration/core/independent_disk_spec.rb
+++ b/spec/integration/core/independent_disk_spec.rb
@@ -22,7 +22,7 @@ describe Vcloud::Core::IndependentDisk do
       @test_disk_size,
       @disk_name_prefix
     )
-    @test_disk = @test_case_disks.first
+    @test_disk = @test_case_disks.shift  # we will delete this disk in the tests
   end
 
   subject(:fixture_disk) { @test_disk }
@@ -102,6 +102,15 @@ describe Vcloud::Core::IndependentDisk do
       }.to raise_error(Vcloud::Core::IndependentDisk::DiskAlreadyExistsException)
     end
 
+  end
+
+  describe "#destroy" do
+    it "after deletion, access to the disk is forbidden (as the API does not distinguish " +
+       "not present and access-denied)" do
+      fixture_disk.destroy
+      expect(fixture_disk.id).to match(/^#{uuid_matcher}$/)
+      expect { fixture_disk.name }.to raise_error(Fog::Compute::VcloudDirector::Forbidden)
+    end
   end
 
   after(:all) do

--- a/spec/vcloud/core/independent_disk_spec.rb
+++ b/spec/vcloud/core/independent_disk_spec.rb
@@ -235,5 +235,16 @@ describe Vcloud::Core::IndependentDisk do
 
   end
 
+  context "#destroy" do
+    subject { Vcloud::Core::IndependentDisk.new(@disk_id) }
+
+    it "deletes the independent disk entity via Fog delete_disk method" do
+      expect(@mock_fog_interface).to receive(:delete_disk).
+        with(subject.id)
+      subject.destroy
+    end
+
+  end
+
 end
 


### PR DESCRIPTION
Once #destroy has been called, the IndependentDisk object
is then in a state where it contains the id of a disk that is no
longer present in the remote VcloudDirector system.

This is exactly the same scenario as if a disk is deleted via other
means, such as via the UI.
