### PR TITLE
[#83470576] Mark missing credentials test as pending

### DIFF
--- a/spec/integration/core/fog/login_spec.rb
+++ b/spec/integration/core/fog/login_spec.rb
@@ -27,6 +27,8 @@ describe Vcloud::Core::Fog::Login do
       end
 
       it "should raise an exception succinctly listing the missing credentials when a token is supplied" do
+        pending "FIXME: Test broken by https://github.com/fog/fog-core/commit/08df3056420fa509079704e9e2ac2dd3a04b987e#diff-ff84bd2420c81ca6f03e176dbc1fbdf7L19\n" \
+          "Remove 'pending' once https://github.com/fog/fog-core/pull/97 is in a released version of Fog"
         expect { subject.token('supersekret') }.to raise_error(
           ArgumentError,
           /^Missing required arguments: vcloud_director_.*$/


### PR DESCRIPTION
This test is currently failing on `master` due to changes upstream in the
fog-core gem.

Specifically, fog/fog-core@08df305 changed the
`::Fog::Errors::LoadError` class but omitted to update a `rescue` line
that refers to that class.

I've raised a pull request against fog-core to fix that issue:
fog/fog-core#97

In the meantime, to fix `master` in a timely manner, mark this test as
pending while we wait for a new release of `fog-core` including the fix
in that PR.

With this fix, the integration tests pass on Skyscape:

``` ruby
Pending:
  Vcloud::Core::Fog::Login#token unable to load credentials should raise an exception succinctly listing the missing credentials when a token is supplied
    # FIXME: Test broken by https://github.com/fog/fog-core/commit/08df3056420fa509079704e9e2ac2dd3a04b987e#diff-ff84bd2420c81ca6f03e176dbc1fbdf7L19
    # ./spec/integration/core/fog/login_spec.rb:29
  Vcloud::Core::Fog::Login#token fog credentials without password environment variable VCLOUD_FOG_TOKEN not set should login and return a token
    # Password not available from environment variable API_PASSWORD
    # ./spec/integration/core/fog/login_spec.rb:49
  Vcloud::Core::Fog::Login#token fog credentials without password environment variable VCLOUD_FOG_TOKEN is set should login and return a token, ignoring the existing token
    # Password not available from environment variable API_PASSWORD
    # ./spec/integration/core/fog/login_spec.rb:63

Finished in 28 minutes 2 seconds
101 examples, 0 failures, 3 pending
```
