### PR TITLE
Sleep in logout test because appears to be async

### DIFF
--- a/spec/integration/core/fog_spec.rb
+++ b/spec/integration/core/fog_spec.rb
@@ -24,6 +24,9 @@ describe Vcloud::Core::Fog do
         expect(fsi.session).to include(:user, :org)
 
         expect(subject).to eq(true)
+        # logout appears to sometimes be slightly asynchronous and doesn't
+        # provide a task that we can monitor the progress of.
+        sleep(1)
 
         fsi = Vcloud::Core::Fog::ServiceInterface.new
         expect{ fsi.session }.to raise_error(


### PR DESCRIPTION
Reluctant and speculative!

---

This integration test very occasionally fails with:

```
1) Vcloud::Core::Fog#logout with a valid token should invalidate a previously working session
   Failure/Error: expect{ fsi.session }.to raise_error(
     expected Fog::Compute::VcloudDirector::Forbidden with "Access is forbidden" but nothing was raised
   # ./spec/integration/core/fog_spec.rb:29:in `block (4 levels) in <top (required)>'
```

It passes again on a subsequent run and is very difficult to reproduce. The
only reason for this that I can think of is that the `/logout` endpoint is
ever so slightly asynchronous and doesn't immediately revoke the session
after return a `204` response. It doesn't provide a task that we can monitor
the progress of so this hack seems to be the only way that we can guard
against the intermittent (and confusing) failure.
