### PR TITLE
Fix jenkins_tests.sh cleanup() trap

### DIFF
--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -2,10 +2,12 @@
 set -eu
 
 function cleanup {
+  set +e
+  bundle exec vcloud-logout
   rm $FOG_RC
+  unset FOG_RC
 }
 
-# Override default of ~/.fog and delete afterwards.
 export FOG_RC=$(mktemp /tmp/vcloud_fog_rc.XXXXXXXXXX)
 trap cleanup EXIT
 
@@ -32,7 +34,6 @@ rm -rf vcloud-tools-testing-config
 # Never log token to STDOUT.
 set +x
 eval $(printenv API_PASSWORD | bundle exec vcloud-login)
-trap "bundle exec vcloud-logout" EXIT
 
 bundle exec rake
 bundle exec rake integration


### PR DESCRIPTION
- Put everything in one function because each `trap … EXIT` overwrites the
  previous definition.
- Call `set +e` at the beginning so that we don't exit prematurely before
  all of the cleanup operations have been run.
- Unset the `FOG_RC` variable when we're done with it. Shouldn't make a
  different to the caller shell, but better safe than sorry and it's
  consistent with the other scripts like this.
- Remove the comment now that `cleanup()` is doing more than just deleting
  the temporary `FOG_RC` file.
