### PR TITLE
[Fixes #151] Pin mustache dependency to 0.99.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.1 (2015-01-15)
+
+Bugfixes:
+
+  - Pin Mustache dependency to 0.99.x to maintain support for Ruby 1.9.3
+
 ## 0.16.0 (2014-12-03)
 
 Features:

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '0.16.0'
+    VERSION = '0.16.1'
   end
 end

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '>= 1.25.0'
-  s.add_runtime_dependency 'mustache'
+  s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Mustache 1.0.0 was released last month and now requires Ruby 2.x:

- mustache/mustache@a719e44

This causes `vcloud-core` and the tools that depend on it to fail
installation on Ruby 1.9.3 if you didn't have an existing `Gemfile.lock`
with a prior version of mustache:

- https://travis-ci.org/gds-operations/vcloud-core/jobs/46725308#L108

Prevent this from happening by pinning to Mustache 0.99.x which appears to
support both 1.9.3 and 2.x - this seems like the best solution for now,
until someone has a pressing reason to use Mustache 1.x

---

I'm releasing this as 0.16.1, even though we plan to go to 1.0, because it'll allow people using the current versions of all tools to pull this in easily.