### PR TITLE
[#86687556] Bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 (2015-01-22)
+
+  - Release 1.0.0 since the public API is now stable
+
 ## 0.16.1 (2015-01-15)
 
 Bugfixes:

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '0.16.1'
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
We have decided that the public API is now stable therefore under
[Semantic Versioning](http://semver.org/) we should release version 1.0.0