### PR TITLE
Allow any version of vcloud-tools-tester

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 0.2.0'
+  s.add_development_dependency 'vcloud-tools-tester'
 end


### PR DESCRIPTION
So we can upgrade release 1.0.0