### PR TITLE
Tighten vcloud-tools-tester dependency

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop', '~> 0.23.0'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 1.0'
 end

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Anna Shipman']
   s.email       = ['anna.shipman@digital.cabinet-office.gov.uk']
   s.summary     = 'Core tools for interacting with VMware vCloud Director'
-  s.description = 'Core tools for interacting with VMware vCloud Director. Includes VCloud Query, a light wrapper round the vCloud Query API.'
+  s.description = 'Core tools for interacting with VMware vCloud Director. Includes vCloud Query, a light wrapper round the vCloud Query API.'
   s.homepage    = 'http://github.com/gds-operations/vcloud-core'
   s.license     = 'MIT'
 


### PR DESCRIPTION
Rather than using the latest release, we should now specify that we use
anything specifically in the 1.0 release. This will pick up anything in the
1 major release (so, 1.1, 1.2 etc.). This makes releases of vcloud-core and
vcloud-tools-tester easier in future.

Also neatens the use of vCloud in the Gemspec.