### PR TITLE
Update Gem ownership

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -8,8 +8,8 @@ require 'vcloud/core/version'
 Gem::Specification.new do |s|
   s.name        = 'vcloud-core'
   s.version     = Vcloud::Core::VERSION
-  s.authors     = ['Anna Shipman']
-  s.email       = ['anna.shipman@digital.cabinet-office.gov.uk']
+  s.authors     = ['GOV.UK Infrastructure']
+  s.email       = ['vcloud-tools@digital.cabinet-office.gov.uk']
   s.summary     = 'Core tools for interacting with VMware vCloud Director'
   s.description = 'Core tools for interacting with VMware vCloud Director. Includes VCloud Query, a light wrapper round the vCloud Query API.'
   s.homepage    = 'http://github.com/gds-operations/vcloud-core'


### PR DESCRIPTION
Per discussion in https://github.com/gds-operations/vcloud-core/issues/157, this fixes the Gem ownership to point to a mailing list rather than an individual.