### PR TITLE
Explicitly set fog-core version

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'fog', '~> 1.27'
+  # FIXME: Remove fog-core line below once fog/fog-core@58556e4b1 is pulled in by `fog` gem
+  s.add_runtime_dependency 'fog-core', '~> 1.0', '>= 1.27.4'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'fog', '>= 1.25.0'
+  s.add_runtime_dependency 'fog', '~> 1.27'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
We wouldn't normally specificy a `fog-core` version because it's already
pulled in by `fog` [1] (and thus not our concern).

But in this case, we set it explicitly so that we can ensure we use
version 1.27.4 and above, which includes this bugfix:

fog/fog-core@58556e4

Without that bugfix, our integration tests (`bundle exec rake integration`) were failing with this error:

    NoMethodError:
          undefined method `redisplay_progressbar' for Fog::Formatador:Class

Note that we change the version pinning slightly to use pessimistic
versioning to prevent us from inadvertently using version 2 of
`fog-core`, while ensuring that we use at least version 1.27.4.

See also the original bug report for vCloud Tools:
https://groups.google.com/a/digital.cabinet-office.gov.uk/d/msg/vcloud-tools/GF-YrOVhUUU/bSQVpWyuaQkJ

[1]: https://github.com/fog/fog/blob/16652f124f22f0d7f4addd44f4bb50dde152bb60/fog.gemspec#L49

* * *

Note that currently, Fog master still [requires only `fog-core` version 1.27.3](https://github.com/fog/fog/blob/16652f124f22f0d7f4addd44f4bb50dde152bb60/fog.gemspec#L49) and above, which is why this error only occurred on some installations.

We raised a PR upstream against Fog to highlight the issue. It's currently failing on jruby but that's a separate issue:
https://github.com/fog/fog/pull/3446