### PR TITLE
mac feature cleanup and cdrom 

### DIFF
--- a/lib/vcloud/core/fog/service_interface.rb
+++ b/lib/vcloud/core/fog/service_interface.rb
@@ -73,7 +73,7 @@ module Vcloud
 
           def put_detach_cdrom(vm_id, media_id) 
             Vcloud::Core.logger.debug("detaching #{media_id} cdrom into VM #{vm_id}")
-            @vcloud.post_insert_cd_rom(vm_id, media_id)
+            @vcloud.post_eject_cd_rom(vm_id, media_id)
           end
 
           def put_network_connection_system_section_vapp(vm_id, section)

--- a/lib/vcloud/core/fog/service_interface.rb
+++ b/lib/vcloud/core/fog/service_interface.rb
@@ -16,7 +16,7 @@ module Vcloud
                        :get_execute_query, :get_vapp_metadata, :power_off_vapp, :shutdown_vapp, :session,
                        :post_instantiate_vapp_template, :put_memory, :put_cpu, :power_on_vapp, :put_vapp_metadata_value,
                        :put_vm, :get_edge_gateway, :get_network_complete, :delete_network, :post_create_org_vdc_network,
-                       :post_configure_edge_gateway_services, :get_vdc, :post_undeploy_vapp,
+                       :put_insert_cdrom, :put_detach_cdrom, :post_configure_edge_gateway_services, :get_vdc, :post_undeploy_vapp,
                        :post_create_disk, :get_disk, :delete_disk, :post_attach_disk,
                        :get_vms_disk_attached_to, :post_detach_disk, :put_product_sections,
                        :logout
@@ -64,6 +64,16 @@ module Vcloud
 
           def get_vapp(id)
             @vcloud.get_vapp(id).body
+          end
+
+          def put_insert_cdrom(vm_id, media_id)
+            Vcloud::Core.logger.debug("inserting #{media_id} cdrom into VM #{vm_id}")
+            @vcloud.post_insert_cd_rom(vm_id, media_id)
+          end
+
+          def put_detach_cdrom(vm_id, media_id) 
+            Vcloud::Core.logger.debug("detaching #{media_id} cdrom into VM #{vm_id}")
+            @vcloud.post_insert_cd_rom(vm_id, media_id)
           end
 
           def put_network_connection_system_section_vapp(vm_id, section)

--- a/lib/vcloud/core/vm.rb
+++ b/lib/vcloud/core/vm.rb
@@ -130,6 +130,28 @@ module Vcloud
         end
       end
 
+      # Insert a cdrom from medias
+      #
+      # @param media_name [String] The name of the media you wish inserted
+      # @return [Boolean] return true or throw an error
+      def insert_cdrom(media_name)
+        if media_name
+          media_id = get_media_id_by_name(media_name)
+          Vcloud::Core::Fog::ServiceInterface.new.put_insert_cdrom(id, media_id)
+        end
+      end
+
+      # Detach a cdrom from VM
+      #
+      # @param media_name [String] The name of the media you wish inserted
+      # @return [Boolean] return true or throw an error
+      def detach_cdrom(media_name)
+        if media_name
+          media_id = get_media_id_by_name(media_name)
+          Vcloud::Core::Fog::ServiceInterface.new.put_detach_cdrom(id, media_id)
+        end
+      end
+
       # Add extra disks to VM
       #
       # @param extra_disks [Array] An array of hashes like [{ size: '20480' }]
@@ -160,13 +182,14 @@ module Vcloud
           }
           ip_address      = network[:ip_address]
           allocation_mode = network[:allocation_mode]
+          mac_address     = network[:mac_address]
 
           allocation_mode = 'manual' if ip_address
           allocation_mode = 'dhcp' unless %w{dhcp manual pool}.include?(allocation_mode)
 
           connection[:IpAddressAllocationMode] = allocation_mode.upcase
           connection[:IpAddress] = ip_address if ip_address
-          connection[:MACAddress] = network[:mac_address] if network[:mac_address]
+          connection[:MACAddress] = mac_address if mac_address
           connection
         end
         Vcloud::Core::Fog::ServiceInterface.new.put_network_connection_system_section_vapp(id, section)
@@ -198,6 +221,26 @@ module Vcloud
 
       def virtual_hardware_section
         vcloud_attributes[:'ovf:VirtualHardwareSection'][:'ovf:Item']
+      end
+
+      def get_media_id_by_name(media_name)
+        media_id = get_media_href_by_name(media_name)
+        media_id.split("/").last
+      end
+
+      def get_media_href_by_name(media_name)
+        q = Vcloud::Core::QueryRunner.new 
+        vdc_results = q.run('vApp', :filter => "name==#{vapp_name}")
+        vdc_name = vdc_results.first[:vdcName]
+
+        q = Vcloud::Core::QueryRunner.new
+        sp_results = q.run('media', :filter => "name==#{media_name};vdcName==#{vdc_name}")
+
+        if sp_results.empty? or !sp_results.first.has_key?(:href)
+          raise "media #{media_name} not found in vdc"
+        else
+          return sp_results.first[:href]
+        end
       end
 
       def get_storage_profile_href_by_name(storage_profile_name, vapp_name)


### PR DESCRIPTION
- changed the mac address code to be more inline with the rest of the method 
- note: it would be nice if the schema validator in the vcloud-launch supported a regex check (though not a buggie)
- added the ability to attach cdroms on the fly to the vm
- @todo: a the moment the media is query uses just the vdc and media name, it's might an idea to add the catalog as well into the query, which is easily grabbed from the parent vapp

