### PR TITLE
Test Ruby version 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.2
 notifications:
   email: false

--- a/spec/support/stub_fog_interface.rb
+++ b/spec/support/stub_fog_interface.rb
@@ -63,9 +63,4 @@ class StubFogInterface
     { }
   end
 
-  def template(_catalog_name, _name)
-    { :href => '/vappTemplate-12345678-90ab-cdef-0123-4567890abcde' }
-  end
-
-
 end

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'
-  s.add_development_dependency 'rubocop', '~> 0.23.0'
+  s.add_development_dependency 'rubocop', '~> 0.30.1'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'vcloud-tools-tester', '~> 1.0'
 end


### PR DESCRIPTION
So that we can have confidence that the code works on the latest Ruby
version and so that we can try to reproduce the issues mentioned here:

https://github.com/gds-operations/vcloud-core/issues/163
https://github.com/gds-operations/vcloud-core/pull/170

__Depends on https://github.com/gds-operations/vcloud-core/pull/170, without which the tests fail.__