### PR TITLE
Bump version from 1.0.2 to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.0 (2015-06-30)
+
+Features:
+
+  - Add the ability to set the MAC address of a VM
+
+Bugfixes:
+
+  - Add an explicit `require 'json'` to the ConfigLoader
+
 ## 1.0.2 (2015-02-24)
 
 Documentation:

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '1.0.2'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
This is the diff I'm planning to go with: https://github.com/gds-operations/vcloud-core/compare/v1.0.2...gds-operations:dafde8f