### PR TITLE
Add additional methods to power off vapps

### DIFF
--- a/lib/vcloud/core/api_interface.rb
+++ b/lib/vcloud/core/api_interface.rb
@@ -46,6 +46,14 @@ module Vcloud
         fog_service_interface.delete_vapp(id)
       end
 
+      # Poweroff a vApp by id
+      #
+      # @param id [String] ID of the vApp to power off
+      # @return [Boolean] return true or throw error
+      def power_off_vapp(id)
+        fog_service_interface.power_off_vapp(id)
+      end
+
       # Delete a network by id
       #
       # @param id [String] ID of the network to delete

--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -164,11 +164,27 @@ module Vcloud
         running?
       end
 
+      # Power off vApp
+      #
+      # @return [Boolean] Returns true if the VM is powered off, false otherwise
+      def power_off
+        raise "Unable to find requested vApp to power off" unless id
+        return true if powered_off?
+        Vcloud::Core::Fog::ServiceInterface.new.power_off_vapp(id)
+        powered_off?
+      end
+
       private
       def running?
         raise "Cannot call running? on a missing vApp." unless id
         vapp = Vcloud::Core::Fog::ServiceInterface.new.get_vapp(id)
         vapp[:status].to_i == STATUS::RUNNING ? true : false
+      end
+
+      def powered_off?
+        raise "Cannot call stopped? on a missing vApp." unless id
+        vapp = Vcloud::Core::Fog::ServiceInterface.new.get_vapp(id)
+        vapp[:status].to_i == STATUS::POWERED_OFF ? true : false
       end
 
       def self.build_network_config(networks)


### PR DESCRIPTION
This requirement came about from a need to delete all running vApps. vApps need to be powered off before you are able to delete them so I am adding in the functionality to be consistent with other methods.