### PR TITLE
Bump Fog version for multiple subnet functionality

### DIFF
--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  # FIXME: Remove fog-core line below once fog/fog-core@58556e4b1 is pulled in by `fog` gem
-  s.add_runtime_dependency 'fog-core', '~> 1.0', '>= 1.27.4'
   s.add_runtime_dependency 'fog', '~> 1.34.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'fog', '~> 1.27'
   # FIXME: Remove fog-core line below once fog/fog-core@58556e4b1 is pulled in by `fog` gem
   s.add_runtime_dependency 'fog-core', '~> 1.0', '>= 1.27.4'
+  s.add_runtime_dependency 'fog', '~> 1.34.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Specifically we need `1.34.0` for fog/fog#3671 which is needed for VPN tunnels in vcloud-edge-gateway