### PR TITLE
Bump vcloud-core Gem version which has new Fog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.0 (2015-09-10)
+
+Bugfixes:
+
+  - Upgrade to Fog version 1.34.0 to support multiple peer and local subnets
+    with vSE IPSEC VPN
+
 ## 1.1.0 (2015-06-30)
 
 Features:

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end


### PR DESCRIPTION
We have pulled in a new release of Fog with added functionality that we need, so need to bump gem here to pull into other vCloud tools.

https://github.com/gds-operations/vcloud-edge_gateway/pull/133

Not yet published to Rubygems.