### PR TITLE
Fix tests for updated fog 1.34 

### DIFF
--- a/spec/integration/core/fog/login_spec.rb
+++ b/spec/integration/core/fog/login_spec.rb
@@ -37,7 +37,7 @@ describe Vcloud::Core::Fog::Login do
     end
 
     context "fog credentials without password" do
-      let(:token_length) { 44 }
+      let(:token_length) { 32 }
       let(:envvar_token) { 'FOG_VCLOUD_TOKEN' }
       let(:envvar_password) { 'API_PASSWORD' }
 

--- a/spec/integration/core/vapp_spec.rb
+++ b/spec/integration/core/vapp_spec.rb
@@ -174,7 +174,7 @@ describe Vcloud::Core::Vapp do
           "invalid-vapp-template-id",
           @test_params.vdc_1_name
         )
-      }.to raise_error(Fog::Compute::VcloudDirector::Forbidden, "This operation is denied.")
+      }.to raise_error(Fog::Compute::VcloudDirector::Forbidden, /This operation is denied/)
     end
 
     it "raises a Fog error if the vAppTemplate id is nil" do

--- a/spec/integration/core/vdc_spec.rb
+++ b/spec/integration/core/vdc_spec.rb
@@ -82,7 +82,7 @@ describe Vcloud::Core::Vdc do
       it "throws a Forbidden error when trying to access the #name of the Vdc" do
         expect { subject.name }.to raise_error(
           Fog::Compute::VcloudDirector::Forbidden,
-          /\ANo access to entity /
+          /No access to entity/
         )
       end
 

--- a/spec/integration/core/vm_spec.rb
+++ b/spec/integration/core/vm_spec.rb
@@ -257,7 +257,7 @@ describe Vcloud::Core::Vm do
       expect { @vm.add_extra_disks(extra_disks) }.
         to raise_error(
           Fog::Compute::VcloudDirector::BadRequest,
-          "The attached disks on VM \"#{@vm.name}\" cannot be modified."
+          /The attached disks on VM \"#{@vm.name}\" cannot be modified/
         )
     end
 
@@ -276,7 +276,7 @@ describe Vcloud::Core::Vm do
           pending("There is only one StorageProfile in vDC #{@test_params.vdc_1_name}: cannot test.")
         end
         expect{ @vm.update_storage_profile(@test_params.storage_profile) }.
-          to raise_error(Fog::Compute::VcloudDirector::TaskError)
+          to raise_error(Fog::Compute::VcloudDirector::TaskError, /attached to a virtual machine/)
       end
     end
   end


### PR DESCRIPTION
Bumping Fog versions in https://github.com/gds-operations/vcloud-core/pull/176 broke some tests. This fixes said tests.

Requires https://github.gds/gds/vcloud-tools-testing-config/pull/14