### PR TITLE
[#91921114] Don't test for length of vCloud login token

### DIFF
--- a/spec/integration/core/fog/login_spec.rb
+++ b/spec/integration/core/fog/login_spec.rb
@@ -37,7 +37,6 @@ describe Vcloud::Core::Fog::Login do
     end
 
     context "fog credentials without password" do
-      let(:token_length) { 32 }
       let(:envvar_token) { 'FOG_VCLOUD_TOKEN' }
       let(:envvar_password) { 'API_PASSWORD' }
 
@@ -61,7 +60,7 @@ describe Vcloud::Core::Fog::Login do
 
           expect(ENV).not_to have_key(envvar_token)
           @temp_token = subject.token(@real_password)
-          expect(@temp_token.size).to eq(token_length)
+          expect(@temp_token).not_to be_empty
         end
       end
 
@@ -76,7 +75,7 @@ describe Vcloud::Core::Fog::Login do
           ENV[envvar_token] = old_token
           @temp_token = subject.token(@real_password)
           expect(@temp_token).to_not eq(old_token)
-          expect(@temp_token.size).to eq(token_length)
+          expect(@temp_token).not_to be_empty
         end
       end
     end


### PR DESCRIPTION
Prior to 36ba0cc1, we asserted that the length of a vCloud Director
login token must be 44 characters.

In 36ba0cc1 we changed that length to 32 characters, I suspect because
a later version of vCloud Director returns token of that length.

Our integration tests are current passing in one provider (Skyscape) but
failing in another (Carrenza), presumably due to a discrepancy in the
versions of vCloud Director they use. Carrenza is returning a token 44
characters long.

Since the exact format of the token is undocumented [1], don't check the
length and only assert that we received a non-empty string. Otherwise,
we risk having to change this value each time VMware change its format.

http://pubs.vmware.com/vcd-56/topic/com.vmware.ICbase/PDF/vcd_56_api_guide.pdf