### PR TITLE
[#91921114] Fix assertion on error message

### DIFF
--- a/spec/integration/core/vdc_spec.rb
+++ b/spec/integration/core/vdc_spec.rb
@@ -80,10 +80,7 @@ describe Vcloud::Core::Vdc do
       end
 
       it "throws a Forbidden error when trying to access the #name of the Vdc" do
-        expect { subject.name }.to raise_error(
-          Fog::Compute::VcloudDirector::Forbidden,
-          /No access to entity/
-        )
+        expect { subject.name }.to raise_error(Fog::Compute::VcloudDirector::Forbidden)
       end
 
     end


### PR DESCRIPTION
This exception now returns `DISALLOWED_OPERATIONS [
com.vmware.vcloud.entity.vdc:12345678-1234-1234-1234-123456789012 ]`
rather than a `No access to entity message`, so update the test
accordingly.

I don't believe there to be any functional difference between the to
messages and I think it's sufficient to check for a `Forbidden`
exception type.

Prevents this error:

    1) Vcloud::Core::Vdc.new when instantiating with a valid UUID, that does not refer to a Vdc throws a Forbidden error when trying to access the #name of the Vdc
      Failure/Error: expect { subject.name }.to raise_error(
        expected Fog::Compute::VcloudDirector::Forbidden with message matching /No access to entity/, got #<Fog::Compute::VcloudDirector::Forbidden: DISALLOWED_OPERATIONS [ com.vmware.vcloud.entity.vdc:12345678-1234-1234-1234-123456789012 ]> with backtrace:
          # ./lib/vcloud/core/fog/service_interface.rb:33:in `get_vdc'
          # ./lib/vcloud/core/vdc.rb:34:in `vcloud_attributes'
          # ./lib/vcloud/core/vdc.rb:41:in `name'
          # ./spec/integration/core/vdc_spec.rb:83:in `block (5 levels) in <top (required)>'
          # ./spec/integration/core/vdc_spec.rb:83:in `block (4 levels) in <top (required)>'
      # ./spec/integration/core/vdc_spec.rb:83:in `block (4 levels) in <top (required)>'