### PR TITLE
Allow plaintext passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
   - Remove support for Ruby 1.9.3, which is now end-of-life.
+  - Reverted changes made in 0.11.0
 
 ## 1.2.0 (2015-09-10)
 

--- a/lib/vcloud/core/fog.rb
+++ b/lib/vcloud/core/fog.rb
@@ -30,7 +30,15 @@ module Vcloud
       # in .fog files.
       #
       def self.check_credentials
-        check_plaintext_pass
+        pass = fog_credentials_pass
+        unless pass.nil? or pass.empty?
+          warn <<EOF
+[WARNING] Storing :vcloud_director_password in your plaintext FOG_RC file is
+          insecure. Future releases of vcloud-core (and tools that depend on
+          it) will prevent you from doing this. Please use vcloud-login to
+          get a session token instead.
+EOF
+        end
       end
 
       # Attempt to load the password from the fog credentials file
@@ -48,20 +56,6 @@ module Vcloud
 
         pass
       end
-
-      private
-
-      # Check whether a plaintext password is in the Fog config
-      # file
-      #
-      # @return [void]
-      def self.check_plaintext_pass
-        pass = fog_credentials_pass
-        unless pass.nil? or pass.empty?
-          raise "Found plaintext #{Vcloud::Core::Fog::FOG_CREDS_PASS_NAME} entry. Please set it to an empty string as storing passwords in plaintext is insecure. See http://gds-operations.github.io/vcloud-tools/usage/ for further information."
-        end
-      end
-
     end
   end
 end

--- a/lib/vcloud/core/fog/login.rb
+++ b/lib/vcloud/core/fog/login.rb
@@ -6,7 +6,6 @@ module Vcloud
       module Login
         class << self
           def token(pass)
-            Vcloud::Core::Fog.check_credentials
             token = get_token(pass)
 
             return token

--- a/spec/vcloud/core/fog/login_spec.rb
+++ b/spec/vcloud/core/fog/login_spec.rb
@@ -4,6 +4,7 @@ require 'stringio'
 describe Vcloud::Core::Fog::Login do
   describe "#token" do
     it "should return the output from get_token" do
+      expect(subject).to receive(:check_plaintext_pass)
       expect(subject).to receive(:get_token).and_return('mekmitasdigoat')
       expect(subject.token('supersekret')).to eq("mekmitasdigoat")
     end
@@ -39,7 +40,7 @@ describe Vcloud::Core::Fog::Login do
         expect(subject).to_not receive(:get_token)
         expect { subject.token('supersekret') }.to raise_error(
           RuntimeError,
-          "Found plaintext vcloud_director_password entry. Please set it to an empty string as storing passwords in plaintext is insecure. See http://gds-operations.github.io/vcloud-tools/usage/ for further information."
+          "Found plaintext vcloud_director_password entry. Please set it to an empty string"
         )
       end
     end


### PR DESCRIPTION
I'm expecting this to be quite controversial, but on our project the choice seemed to be this or using expect (ugh). Skyscape has no way of authenticating other than a username/password with a short expiry, and we want to use CI to keep our edge gateway up-to-date with our repository.

I'm sure there's some tidying up I should do (a working spec test, for one), but I'm sure there's some discussion to be had first. Quite happy to be shown an alternative way of handling this issue.