### PR TITLE
Upgrade fog from at least 1.34 to at least 1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+sudo: true
 rvm:
   - 2.0.0
   - 2.1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: true
 rvm:
   - 2.0.0
-  - 2.1.2
+  - 2.1.8
   - 2.2.2
 notifications:
   email: false

--- a/lib/vcloud/core.rb
+++ b/lib/vcloud/core.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'open3'
 require 'vcloud/core/fog'
 require 'vcloud/core/api_interface'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'fog', '~> 1.34.0'
+  s.add_runtime_dependency 'fog', '~> 1.36.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
There's a bug in fog 1.34 and 1.35 where [`net/ssh` wasn't removed properly][1] which is causing problems. Bumping the requirement to at least 1.36 fixes the issue.

However bumping the version of fog causes our tests to fail with the error:

```
     NameError:
       uninitialized constant Vcloud::Core::Logger
     # ./lib/vcloud/core.rb:31:in `logger'
     # ./spec/vcloud/core/config_loader_spec.rb:54:in `block (3 levels) in <top (required)>'
```

I'm not sure why this upgrade has caused that to break, but explicitly requiring the Logger class in that module fixes it.

[1]: https://github.com/fog/fog/issues/3765