### PR TITLE
Upgrade rspec to later version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1 (2017-06-09)
+
+  - Bug fix related to the `last_comment` method being removed in Rake
+  - Pinned nokogiri to work with Ruby 2.0
+  - Upgraded rspec
+  - Various bug fixes
+
 ## 2.0.0 (2015-12-24)
 
   - Remove support for Ruby 1.9.3, which is now end-of-life.

--- a/lib/vcloud/core/fog.rb
+++ b/lib/vcloud/core/fog.rb
@@ -49,8 +49,6 @@ module Vcloud
         pass
       end
 
-      private
-
       # Check whether a plaintext password is in the Fog config
       # file
       #

--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -164,6 +164,10 @@ module Vcloud
         running?
       end
 
+      def self.id_prefix
+        'vapp'
+      end
+
       private
       def running?
         raise "Cannot call running? on a missing vApp." unless id
@@ -171,7 +175,7 @@ module Vcloud
         vapp[:status].to_i == STATUS::RUNNING ? true : false
       end
 
-      def self.build_network_config(networks)
+      private_class_method def self.build_network_config(networks)
         return {} unless networks
         instantiation = { NetworkConfigSection: {NetworkConfig: []} }
         networks.compact.each do |network|
@@ -186,11 +190,7 @@ module Vcloud
         instantiation
       end
 
-      def self.id_prefix
-        'vapp'
-      end
-
-      def self.get_networks(network_names, vdc_name)
+      private_class_method def self.get_networks(network_names, vdc_name)
         fsi = Vcloud::Core::Fog::ServiceInterface.new
         fsi.find_networks(network_names, vdc_name) if network_names
       end

--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -175,7 +175,7 @@ module Vcloud
         vapp[:status].to_i == STATUS::RUNNING ? true : false
       end
 
-      private_class_method def self.build_network_config(networks)
+      def build_network_config(networks)
         return {} unless networks
         instantiation = { NetworkConfigSection: {NetworkConfig: []} }
         networks.compact.each do |network|
@@ -190,10 +190,11 @@ module Vcloud
         instantiation
       end
 
-      private_class_method def self.get_networks(network_names, vdc_name)
+      def get_networks(network_names, vdc_name)
         fsi = Vcloud::Core::Fog::ServiceInterface.new
         fsi.find_networks(network_names, vdc_name) if network_names
       end
+
     end
   end
 end

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end

--- a/lib/vcloud/core/vm.rb
+++ b/lib/vcloud/core/vm.rb
@@ -195,6 +195,10 @@ module Vcloud
         })
       end
 
+      def self.id_prefix
+        'vm'
+      end
+
       private
 
       def virtual_hardware_section
@@ -216,11 +220,6 @@ module Vcloud
         end
       end
 
-      def self.id_prefix
-        'vm'
-      end
-
     end
-
   end
 end

--- a/spec/integration/core/query_runner_spec.rb
+++ b/spec/integration/core/query_runner_spec.rb
@@ -39,39 +39,39 @@ module Vcloud
         context "it supports all the vCloud entity types our tools need" do
 
           it "supports the vApp entity type" do
-            expect(@query_types.include?("vApp")).to be_true
+            expect(@query_types.include?("vApp")).to be true
           end
 
           it "supports the vm entity type" do
-            expect(@query_types.include?("vm")).to be_true
+            expect(@query_types.include?("vm")).to be true
           end
 
           it "supports the orgVdc entity type" do
-            expect(@query_types.include?("orgVdc")).to be_true
+            expect(@query_types.include?("orgVdc")).to be true
           end
 
           it "supports the orgVdcNetwork entity type" do
-            expect(@query_types.include?("orgVdcNetwork")).to be_true
+            expect(@query_types.include?("orgVdcNetwork")).to be true
           end
 
           it "supports the edgeGateway entity type" do
-            expect(@query_types.include?("edgeGateway")).to be_true
+            expect(@query_types.include?("edgeGateway")).to be true
           end
 
           it "supports the task entity type" do
-            expect(@query_types.include?("task")).to be_true
+            expect(@query_types.include?("task")).to be true
           end
 
           it "supports the catalog entity type" do
-            expect(@query_types.include?("catalog")).to be_true
+            expect(@query_types.include?("catalog")).to be true
           end
 
           it "supports the catalogItem entity type" do
-            expect(@query_types.include?("catalogItem")).to be_true
+            expect(@query_types.include?("catalogItem")).to be true
           end
 
           it "supports the vAppTemplate entity type" do
-            expect(@query_types.include?("vAppTemplate")).to be_true
+            expect(@query_types.include?("vAppTemplate")).to be true
           end
 
         end

--- a/spec/integration/core/vapp_spec.rb
+++ b/spec/integration/core/vapp_spec.rb
@@ -89,7 +89,7 @@ describe Vcloud::Core::Vapp do
 
     it "powers up a powered down Vapp" do
       expect(Integer(fixture_vapp.vcloud_attributes[:status])).to eq(Vcloud::Core::Vapp::STATUS::POWERED_OFF)
-      expect(fixture_vapp.power_on).to be_true
+      expect(fixture_vapp.power_on).to be true
       expect(Integer(fixture_vapp.vcloud_attributes[:status])).to eq(Vcloud::Core::Vapp::STATUS::RUNNING)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,11 +9,13 @@ if ENV['COVERAGE']
     end
   end
 
-  SimpleCov.adapters.define 'gem' do
-    add_filter '/spec/'
-    add_filter '/vendor/'
+  if SimpleCov.profiles[:gem].nil?
+    SimpleCov.profiles.define 'gem' do
+      add_filter '/spec/'
+      add_filter '/vendor/'
 
-    add_group 'Libraries', '/lib/'
+      add_group 'Libraries', '/lib/'
+    end
   end
 
   SimpleCov.minimum_coverage(84)

--- a/spec/vcloud/core/config_validator_spec.rb
+++ b/spec/vcloud/core/config_validator_spec.rb
@@ -8,21 +8,21 @@ describe Vcloud::Core::ConfigValidator do
       data = "hello world"
       schema = { type: String }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should be ok with type as string 'String'" do
       data = "hello world"
       schema = { type: 'String' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should be ok with type as string 'string'" do
       data = "hello world"
       schema = { type: 'string' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
   end
@@ -33,14 +33,14 @@ describe Vcloud::Core::ConfigValidator do
       data = "hello world"
       schema = { type: 'string' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should not validate a number as a basic string" do
       data = 42
       schema = { type: 'string' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_false
+      expect(v.valid?).to be false
     end
 
     it "should log error with number as a basic string" do
@@ -68,7 +68,7 @@ describe Vcloud::Core::ConfigValidator do
       data = ""
       schema = { type: 'string', allowed_empty: true }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should return error for nil value with allowed_empty: true)" do
@@ -82,7 +82,7 @@ describe Vcloud::Core::ConfigValidator do
       data = "name-1234"
       schema = { type: 'string', matcher: /^name-\d+$/ }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should return errror with a :matcher regex not matching" do
@@ -106,7 +106,7 @@ describe Vcloud::Core::ConfigValidator do
       }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should not validate a bogus hash" do
@@ -119,7 +119,7 @@ describe Vcloud::Core::ConfigValidator do
       }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_false
+      expect(v.valid?).to be false
     end
 
     it "should return correct errors validating a bogus hash" do
@@ -156,7 +156,7 @@ describe Vcloud::Core::ConfigValidator do
       data = {}
       schema = { type: 'hash', allowed_empty: true }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should validate ok with a missing parameter, when marked :required => false" do
@@ -171,7 +171,7 @@ describe Vcloud::Core::ConfigValidator do
       }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should return error with a missing :required => true param" do
@@ -222,7 +222,7 @@ describe Vcloud::Core::ConfigValidator do
       },
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
   end
@@ -236,7 +236,7 @@ describe Vcloud::Core::ConfigValidator do
         each_element_is: { type: "string" }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should validate a bogus array" do
@@ -246,7 +246,7 @@ describe Vcloud::Core::ConfigValidator do
         each_element_is: { type: "string" }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_false
+      expect(v.valid?).to be false
     end
 
     it "should return correct errors validating a bogus array" do
@@ -280,7 +280,7 @@ describe Vcloud::Core::ConfigValidator do
       data = []
       schema = { type: 'array', allowed_empty: true }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
   end
@@ -303,7 +303,7 @@ describe Vcloud::Core::ConfigValidator do
       }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should correctly error on an invalid an array of hashes" do
@@ -351,7 +351,7 @@ describe Vcloud::Core::ConfigValidator do
       }
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should correctly error on an invalid hash of arrays" do
@@ -373,7 +373,7 @@ describe Vcloud::Core::ConfigValidator do
       },
       }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
   end
@@ -384,14 +384,14 @@ describe Vcloud::Core::ConfigValidator do
       data = 2
       schema = { type: 'string_or_number' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should correctly validate a String" do
       data = '2'
       schema = { type: 'string_or_number' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should correctly error if not a string or numeric" do
@@ -409,7 +409,7 @@ describe Vcloud::Core::ConfigValidator do
       data = '192.168.100.100'
       schema = { type: 'ip_address' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
 
     it "should correctly error on an invalid IP address" do
@@ -434,14 +434,14 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100.100/24'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
       end
 
       it "should return error if network bit value is greater than 32" do
         data = '192.168.100.100/33'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
 
@@ -449,7 +449,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100.100/33'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 192.168.100.100/33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
 
@@ -457,7 +457,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100./33'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 192.168.100./33 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
     end
@@ -467,7 +467,7 @@ describe Vcloud::Core::ConfigValidator do
         it "should validate OK if IP range is '#{data}'" do
           schema = { type: 'ip_address_range' }
           v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-          expect(v.valid?).to be_true
+          expect(v.valid?).to be true
           expect(v.errors).to be_empty
         end
       end
@@ -476,7 +476,7 @@ describe Vcloud::Core::ConfigValidator do
         data = 'invalid_ip_range_string'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: invalid_ip_range_string is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
     end
@@ -486,7 +486,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100.100-192.168.100.110'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
         expect(v.errors).to be_empty
       end
 
@@ -494,7 +494,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100-192.168.100.110'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 192.168.100-192.168.100.110 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
 
@@ -502,7 +502,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '192.168.100.110-192.168.100'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 192.168.100.110-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
 
@@ -510,7 +510,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '200.168.100.99-192.168.100'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 200.168.100.99-192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
 
@@ -518,7 +518,7 @@ describe Vcloud::Core::ConfigValidator do
         data = '190.168.100.99:192.168.100'
         schema = { type: 'ip_address_range' }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: 190.168.100.99:192.168.100 is not a valid IP address range. Valid values can be IP address, CIDR, IP range, 'Any','internal' and 'external'."])
       end
     end
@@ -527,7 +527,7 @@ describe Vcloud::Core::ConfigValidator do
       data = '190.168.100.99'
       schema = { type: 'ip_address_range' }
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
       expect(v.errors).to eq([])
     end
   end
@@ -550,7 +550,7 @@ describe Vcloud::Core::ConfigValidator do
       data = 'allow'
       schema = { type: 'enum', required: false, acceptable_values: ['allow', 'decline', 'none']}
       v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-      expect(v.valid?).to be_true
+      expect(v.valid?).to be true
     end
   end
 
@@ -566,7 +566,7 @@ describe Vcloud::Core::ConfigValidator do
       it "should validate ok if value is #{boolean_value}" do
         schema = { type: 'boolean' }
         v = Vcloud::Core::ConfigValidator.validate(:base, boolean_value, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
       end
     end
   end
@@ -589,7 +589,7 @@ describe Vcloud::Core::ConfigValidator do
         }
         }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
         expect(v.warnings).to eq(["name: is deprecated by 'full_name'"])
       end
 
@@ -602,7 +602,7 @@ describe Vcloud::Core::ConfigValidator do
         }
         }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
         expect(v.warnings).to eq(["name: is deprecated by 'full_name'"])
       end
 
@@ -615,7 +615,7 @@ describe Vcloud::Core::ConfigValidator do
         }
         }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_true
+        expect(v.valid?).to be true
         expect(v.warnings).to eq(["name: is deprecated by 'full_name'"])
       end
     end
@@ -633,7 +633,7 @@ describe Vcloud::Core::ConfigValidator do
         }
         }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq(["base: missing 'full_name' parameter"])
       end
 
@@ -663,7 +663,7 @@ describe Vcloud::Core::ConfigValidator do
         }
         }
         v = Vcloud::Core::ConfigValidator.validate(:base, data, schema)
-        expect(v.valid?).to be_false
+        expect(v.valid?).to be false
         expect(v.errors).to eq([
                                "name: 123 is not a string",
                                "full_name: 123 is not a string",

--- a/spec/vcloud/core/metadata_helper_spec.rb
+++ b/spec/vcloud/core/metadata_helper_spec.rb
@@ -33,7 +33,7 @@ describe Vcloud::Core::MetadataHelper do
       expect(metadata[:role_name]).to eq('james-bond')
       expect(metadata[:server_number]).to eq(-10)
       expect(metadata[:created_at]).to eq(DateTime.parse("2013-12-16T14:30:05.000Z"))
-      expect(metadata[:daily_shutdown]).to be_false
+      expect(metadata[:daily_shutdown]).to be false
     end
 
     it "should skip metadata entry if entry type is not application/vnd.vmware.vcloud.metadata.value+xml" do

--- a/spec/vcloud/core/vapp_spec.rb
+++ b/spec/vcloud/core/vapp_spec.rb
@@ -140,7 +140,7 @@ describe Vcloud::Core::Vapp do
         )
         expect(@mock_fog_interface).to receive(:power_on_vapp).with(vapp.id)
         state = vapp.power_on
-        expect(state).to be_true
+        expect(state).to be true
       end
 
       it "should not power on a vapp that is already powered on, but should return true" do
@@ -150,7 +150,7 @@ describe Vcloud::Core::Vapp do
         )
         expect(@mock_fog_interface).not_to receive(:power_on_vapp)
         state = vapp.power_on
-        expect(state).to be_true
+        expect(state).to be true
       end
     end
 

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 2.14.1'
+  s.add_development_dependency 'rspec', '>= 3.6'
   s.add_development_dependency 'rubocop', '~> 0.30.1'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'vcloud-tools-tester'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 12'
   s.add_development_dependency 'rspec', '>= 3.6'
   s.add_development_dependency 'rubocop', '~> 0.49.1'
-  s.add_development_dependency 'simplecov', '~> 0.7.1'
+  s.add_development_dependency 'simplecov', '~> 0.14.1'
   s.add_development_dependency 'vcloud-tools-tester'
 end

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fog', '~> 1.36.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
+  s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -28,9 +28,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '>= 12'
   s.add_development_dependency 'rspec', '>= 3.6'
-  s.add_development_dependency 'rubocop', '~> 0.30.1'
+  s.add_development_dependency 'rubocop', '~> 0.49.1'
   s.add_development_dependency 'simplecov', '~> 0.7.1'
   s.add_development_dependency 'vcloud-tools-tester'
 end


### PR DESCRIPTION
the last_comment method was removed in Rake, and this is fixed in a later version of rspec.

Ref: https://github.com/rspec/rspec-core/pull/2197