### PR TITLE
Fix builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,8 @@ node {
     }
 
     stage("bundle install") {
-      sh('source ./rbenv_version.sh')
-      govuk.bundleApp()
+      govuk.setEnvar("RBENV_VERSION", "2.2.2")
+      govuk.bundleGem()
     }
 
     stage("Run tests") {


### PR DESCRIPTION
Fails on `source: not found`, so rather than try to source the file, move the logic into the Jenkinsfile itself.

Use the `bundleGem` method rather than `bundleApp` as we do not have a Gemfile.lock present.