### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.1.0 (2017-06-22)
+
+  - Removed support for Ruby older than 2.2.2
+  - Added support for Ruby 2.3.0 and 2.4.0
+  - Various bug fixes
+  - Updated version of Fog (1.40)
+
 ## 2.0.1 (2017-06-09)
 
   - Bug fix related to the `last_comment` method being removed in Rake

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
 
     if (env.BRANCH_NAME == "master") {
       stage("Publish gem") {
-        sh('bundle exec rake publish_gem')
+        govuk.publishGem(repoName, env.BRANCH_NAME)
       }
     }
   } catch (e) {

--- a/lib/vcloud/core/version.rb
+++ b/lib/vcloud/core/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module Core
-    VERSION = '2.0.1'
+    VERSION = '2.1.0'
   end
 end

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_runtime_dependency 'fog', '~> 1.36.0'
+  s.add_runtime_dependency 'fog', '~> 1.40.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'
   s.add_runtime_dependency 'highline'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8.1'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.2'
 
   s.add_runtime_dependency 'fog', '~> 1.36.0'
   s.add_runtime_dependency 'mustache', '~> 0.99.0'

--- a/vcloud-core.gemspec
+++ b/vcloud-core.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '>= 3.6'
   s.add_development_dependency 'rubocop', '~> 0.49.1'
   s.add_development_dependency 'simplecov', '~> 0.14.1'
-  s.add_development_dependency 'vcloud-tools-tester', '>= 2.0.0'
+  s.add_development_dependency 'vcloud-tools-tester', '>= 2.1.0'
 end


### PR DESCRIPTION
Release 2.1.0 of vcloud-core:

  - Removed support for Ruby older than 2.2.2
  - Added support for Ruby 2.3.0 and 2.4.0
  - Various bug fixes
  - Updated version of Fog (1.40)

https://trello.com/c/0uDbDpkt/574-update-dependencies-on-vcloud-tools