### PR TITLE
Bugfix private methods error

### DIFF
--- a/lib/vcloud/core/vapp.rb
+++ b/lib/vcloud/core/vapp.rb
@@ -175,7 +175,7 @@ module Vcloud
         vapp[:status].to_i == STATUS::RUNNING ? true : false
       end
 
-      def build_network_config(networks)
+      private_class_method def self.build_network_config(networks)
         return {} unless networks
         instantiation = { NetworkConfigSection: {NetworkConfig: []} }
         networks.compact.each do |network|
@@ -190,7 +190,7 @@ module Vcloud
         instantiation
       end
 
-      def get_networks(network_names, vdc_name)
+      private_class_method def self.get_networks(network_names, vdc_name)
         fsi = Vcloud::Core::Fog::ServiceInterface.new
         fsi.find_networks(network_names, vdc_name) if network_names
       end


### PR DESCRIPTION
When running vcloud-launcher the following error appeared:

```
undefined method `get_networks' for Vcloud::Core::Vapp:Class
```

This was due to a change I made in
111d52a43a4deb45fec2b492475bd445b5aac623 which I made because Rubocop
tests were failing. I have reverted this change because now Rubocop does
not complain.

Release a new version with this fix.